### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,5 @@ Full working references are available at [examples](examples)
 | endpoint | Management endpoint of the EKS Cluster |
 | kubeconfig | Contents of the kubeconfig file used to connect to the cluster for management.  Value should be retrieved with CLI or SDK to ensure proper formatting |
 | name | Assigned name of the EKS Cluster |
+| setup | Default EKS bootstrapping script for EC2 |
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Full working references are available at [examples](examples)
 | subnets | List of public and private subnets used for the EKS control plane. | list | - | yes |
 | worker_roles | List of IAM roles assigned to worker nodes. | list | `<list>` | no |
 | worker_roles_count | The number of worker IAM roles provided. | string | `0` | no |
+| bootstrap_arguments | Any optional parameters for the EKS Bootstrapping script. This is ignored for all os's except amazon EKS | string | - | no |
 
 ## Outputs
 


### PR DESCRIPTION
doc was missing `bootstrap_arguments` from inputs and `setup` from outputs.