### PR TITLE
Update docs and worker AMI filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This module creates an EKS cluster, associated cluster IAM role, and applies EKS worker policies to the worker node IAM roles.
 
-The module will output the required configuration files to enable client and worker node setup and configuration.
+In order to get a working cluster: manual steps must be performed **after** the cluster is built.  The module will output the required configuration files to enable client and worker node setup and configuration.
 
 ## Basic Usage
 

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -45,7 +45,7 @@ data "aws_ami" "eks" {
 
   filter {
     name   = "name"
-    values = ["amazon-eks-node-*"]
+    values = ["amazon-eks-node-${var.kubernetes_version}*"]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
  *
  *This module creates an EKS cluster, associated cluster IAM role, and applies EKS worker policies to the worker node IAM roles.
  *
- * The module will output the required configuration files to enable client and worker node setup and configuration.
+ * In order to get a working cluster: manual steps must be performed **after** the cluster is built.  The module will output the required configuration files to enable client and worker node setup and configuration.
  *
  *## Basic Usage
  *


### PR DESCRIPTION
##### Summary of change(s):

update docs and examples, no code changes

We came across an issue where AWS released the v1.11 AMI _before_ they
released the v1.10 AMI. So, simply choosing the latest AMI actually
selected the newest v1.10 AMI for a v1.11 cluster. If we include the k8s
version number we can ensure we're getting the latest AMI for the
cluster version.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

no

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

no

##### If input variables or output variables have changed or has been added, have you updated the README?

NA

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.