### PR TITLE
Add support for Cluster Autoscaler and ALB Ingress Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ This repository contains several terraform modules that can be used to deploy va
 
 ## Module listing
 
-- [cluster](.modules/cluster) This module creates an EKS cluster, associated cluster IAM role, and applies EKS worker policies to the worker node IAM roles.
+- [cluster](./modules/cluster) This module creates an EKS cluster, associated cluster IAM role, and applies EKS worker policies to the worker node IAM roles.
+- [kubernetes_components](./modules/kubernetes_components) This module manages EKS via the kubernetes plugin, enabling additional features like ALB Ingress and Cluster Autoscaler.

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -10,7 +10,7 @@ In order to get a working cluster: manual steps must be performed **after** the 
 
 ```
 module "eks_cluster" {
- source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/cluster/?ref=v0.0.4"
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/cluster/?ref=v0.0.5"
 
  name = "${local.eks_cluster_name}"
  subnets = "${concat(module.vpc.private_subnets, module.vpc.public_subnets)}" #  Required
@@ -33,6 +33,7 @@ Full working references are available at [examples](examples)
 | name | The desired name for the EKS cluster. | string | n/a | yes |
 | security\_groups | List of security groups to apply to the EKS Control Plane.  These groups should enable access to the EKS Worker nodes. | list | n/a | yes |
 | subnets | List of public and private subnets used for the EKS control plane. | list | n/a | yes |
+| wait\_for\_cluster | A variable to control whether we pause deployment after creating the EKS cluster to allow time to fully launch. | string | `"true"` | no |
 | worker\_roles | List of IAM roles assigned to worker nodes. | list | `<list>` | no |
 | worker\_roles\_count | The number of worker IAM roles provided. | string | `"0"` | no |
 
@@ -43,6 +44,11 @@ Full working references are available at [examples](examples)
 | aws\_auth\_cm | Contents of the aws-auth-cm.yaml used for cluster configuration.  Value should be retrieved with CLI or SDK to ensure proper formatting |
 | certificate\_authority\_data | Assigned CA data for the EKS Cluster |
 | endpoint | Management endpoint of the EKS Cluster |
+| iam\_alb\_ingress | ARN of the EKS Cluster Node ALB Ingress Controller IAM policy |
+| iam\_all\_node\_policies | ARN of all EKS Cluster Node IAM polices |
+| iam\_autoscaler | ARN of the EKS Cluster Node Cluster Autoscaler IAM policy |
+| iam\_cw\_logs | ARN of the EKS Cluster Node Cloudwatch Logs IAM policy |
+| kube\_map\_roles | The string value used to configure the cluster with the kubernetes_config_map resource |
 | kubeconfig | Contents of the kubeconfig file used to connect to the cluster for management.  Value should be retrieved with CLI or SDK to ensure proper formatting |
 | name | Assigned name of the EKS Cluster |
 | setup | Default EKS bootstrapping script for EC2 |

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -27,7 +27,9 @@ Full working references are available at [examples](examples)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| alb\_ingress\_controller\_enable | A boolean value that determines if IAM policies related to ALB ingress controller should be created. | string | `"true"` | no |
 | bootstrap\_arguments | Any optional parameters for the EKS Bootstrapping script. This is ignored for all os's except amazon EKS | string | `""` | no |
+| cluster\_autoscaler\_enable | A boolean value that determines if IAM policies related to cluster autoscaler should be created. | string | `"true"` | no |
 | enabled\_cluster\_log\_types | A list of the desired control plane logging to enable. All logs are enabled by default. | list | `<list>` | no |
 | kubernetes\_version | The desired Kubernetes version for your cluster. If you do not specify a value here, the latest version available in Amazon EKS is used. | string | `""` | no |
 | name | The desired name for the EKS cluster. | string | n/a | yes |

--- a/modules/cluster/examples/example.tf
+++ b/modules/cluster/examples/example.tf
@@ -16,7 +16,9 @@ module "vpc" {
 
   vpc_name = "Test1VPC"
 
-  custom_tags = "${map("kubernetes.io/cluster/${local.eks_cluster_name}", "shared")}"
+  custom_tags = {
+    "kubernetes.io/cluster/${local.eks_cluster_name}" = "shared"
+  }
 }
 
 module "sg" {

--- a/modules/cluster/examples/example.tf
+++ b/modules/cluster/examples/example.tf
@@ -12,7 +12,7 @@ locals {
 }
 
 module "vpc" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.10"
 
   vpc_name = "Test1VPC"
 
@@ -20,14 +20,14 @@ module "vpc" {
 }
 
 module "sg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.5"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.6"
 
   resource_name = "Test-SG"
   vpc_id        = "${module.vpc.vpc_id}"
 }
 
 module "eks" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/cluster?ref=v0.0.4"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/cluster?ref=v0.0.5"
 
   name               = "${local.eks_cluster_name}"
   subnets            = "${concat(module.vpc.private_subnets, module.vpc.public_subnets)}" #  Required
@@ -50,7 +50,7 @@ data "aws_ami" "eks" {
 }
 
 module "ec2_asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.6"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.24"
   ec2_os = "amazoneks"
 
   subnets                   = ["${module.vpc.private_subnets}"]

--- a/modules/cluster/examples/outputs.tf
+++ b/modules/cluster/examples/outputs.tf
@@ -1,9 +1,0 @@
-output "kubeconfig" {
-  description = "output of the kubeconfig"
-  value       = "${module.eks.kubeconfig}"
-}
-
-output "aws_auth_cm" {
-  description = "output of the aws auth"
-  value       = "${module.eks.aws_auth_cm}"
-}

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -11,7 +11,7 @@
  *
  *```
  *module "eks_cluster" {
- *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/cluster/?ref=v0.0.4"
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/cluster/?ref=v0.0.5"
  *
  *  name = "${local.eks_cluster_name}"
  *  subnets = "${concat(module.vpc.private_subnets, module.vpc.public_subnets)}" #  Required
@@ -90,6 +90,8 @@ data "template_file" "kubeconfig" {
     endpoint     = "${aws_eks_cluster.cluster.endpoint}"
     cadata       = "${aws_eks_cluster.cluster.certificate_authority.0.data}"
   }
+
+  depends_on = ["null_resource.cluster_launch"]
 }
 
 data "aws_iam_role" "worker_roles" {
@@ -99,10 +101,227 @@ data "aws_iam_role" "worker_roles" {
 }
 
 data "template_file" "aws_auth_cm" {
-  count    = "${var.worker_roles_count}"
+  count = "${var.worker_roles_count}"
+
   template = "${file("${path.module}/text/aws-auth-cm.yaml")}"
 
   vars = {
     iam_role = "${element(data.aws_iam_role.worker_roles.*.arn, count.index)}"
   }
+}
+
+data "template_file" "map_roles" {
+  count = "${var.worker_roles_count}"
+
+  template = "${file("${path.module}/text/map_roles.txt")}"
+
+  vars = {
+    iam_role = "${element(data.aws_iam_role.worker_roles.*.arn, count.index)}"
+  }
+}
+
+resource "null_resource" "cluster_launch" {
+  count = "${var.wait_for_cluster ? 1 : 0}"
+
+  # Sleep for 60 seconds to (hopefully) ensure the cluster is ready before attempting to create
+  # the ConfigMap, etc.
+  #
+  # An unfortunate, seemingly necessary hack to avoid the following timeout error due to slowpoke DNS:
+  #   Post <cluster_endpoint>/api/v1/<..etc..>: dial tcp w.x.y.z:443: i/o timeout
+  #
+  # Once https://github.com/terraform-providers/terraform-provider-aws/pull/11426 has been resolved,
+  # we should be able to remove this sleep command.
+
+  provisioner "local-exec" {
+    command = "sleep 60"
+  }
+  triggers = {
+    cluster_endpoint = "${aws_eks_cluster.cluster.endpoint}"
+  }
+}
+
+data "aws_iam_policy_document" "autoscaler" {
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "autoscaler" {
+  description = "Permissions for the EKS autoscaler"
+  name_prefix = "${var.name}-Cluster-Autoscaler"
+  path        = "/"
+  policy      = "${data.aws_iam_policy_document.autoscaler.json}"
+}
+
+data "aws_iam_policy_document" "cw_logs" {
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "cloudwatch:PutMetricData",
+      "ec2:DescribeTags",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+      "logs:DescribeLogGroups",
+      "logs:CreateLogStream",
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy",
+    ]
+  }
+
+  statement {
+    actions   = ["ssm:GetParameter"]
+    effect    = "Allow"
+    resources = ["arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*"]
+  }
+}
+
+resource "aws_iam_policy" "cw_logs" {
+  description = "Permissions for Cloudwatch logs"
+  name_prefix = "${var.name}-Cloudwatch-Logs"
+  path        = "/"
+  policy      = "${data.aws_iam_policy_document.cw_logs.json}"
+}
+
+data "aws_iam_policy_document" "alb_ingress" {
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "acm:DescribeCertificate",
+      "acm:ListCertificates",
+      "acm:GetCertificate",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeAddresses",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeInternetGateways",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVpcs",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:RevokeSecurityGroupIngress",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "elasticloadbalancing:AddListenerCertificates",
+      "elasticloadbalancing:AddTags",
+      "elasticloadbalancing:CreateListener",
+      "elasticloadbalancing:CreateLoadBalancer",
+      "elasticloadbalancing:CreateRule",
+      "elasticloadbalancing:CreateTargetGroup",
+      "elasticloadbalancing:DeleteListener",
+      "elasticloadbalancing:DeleteLoadBalancer",
+      "elasticloadbalancing:DeleteRule",
+      "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:DeregisterTargets",
+      "elasticloadbalancing:DescribeListenerCertificates",
+      "elasticloadbalancing:DescribeListeners",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeLoadBalancerAttributes",
+      "elasticloadbalancing:DescribeRules",
+      "elasticloadbalancing:DescribeSSLPolicies",
+      "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeTargetGroupAttributes",
+      "elasticloadbalancing:DescribeTargetHealth",
+      "elasticloadbalancing:ModifyListener",
+      "elasticloadbalancing:ModifyLoadBalancerAttributes",
+      "elasticloadbalancing:ModifyRule",
+      "elasticloadbalancing:ModifyTargetGroup",
+      "elasticloadbalancing:ModifyTargetGroupAttributes",
+      "elasticloadbalancing:RegisterTargets",
+      "elasticloadbalancing:RemoveListenerCertificates",
+      "elasticloadbalancing:RemoveTags",
+      "elasticloadbalancing:SetIpAddressType",
+      "elasticloadbalancing:SetSecurityGroups",
+      "elasticloadbalancing:SetSubnets",
+      "elasticloadbalancing:SetWebACL",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "iam:CreateServiceLinkedRole",
+      "iam:GetServerCertificate",
+      "iam:ListServerCertificates",
+    ]
+  }
+
+  statement {
+    actions   = ["cognito-idp:DescribeUserPoolClient"]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "waf-regional:GetWebACLForResource",
+      "waf-regional:GetWebACL",
+      "waf-regional:AssociateWebACL",
+      "waf-regional:DisassociateWebACL",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "tag:GetResources",
+      "tag:TagResources",
+    ]
+  }
+
+  statement {
+    actions   = ["waf:GetWebACL"]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "alb_ingress" {
+  description = "Permissions for ALB Ingress Controller"
+  name_prefix = "${var.name}-Alb-Ingress"
+  path        = "/"
+  policy      = "${data.aws_iam_policy_document.alb_ingress.json}"
 }

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -6,16 +6,48 @@ output "aws_auth_cm" {
 output "certificate_authority_data" {
   description = "Assigned CA data for the EKS Cluster"
   value       = "${aws_eks_cluster.cluster.certificate_authority.0.data}"
+  depends_on  = ["null_resource.cluster_launch"]
 }
 
 output "endpoint" {
   description = "Management endpoint of the EKS Cluster"
   value       = "${aws_eks_cluster.cluster.endpoint}"
+  depends_on  = ["null_resource.cluster_launch"]
+}
+
+output "iam_alb_ingress" {
+  description = "ARN of the EKS Cluster Node ALB Ingress Controller IAM policy"
+  value       = "${aws_iam_policy.alb_ingress.arn}"
+}
+
+output "iam_all_node_policies" {
+  description = "ARN of all EKS Cluster Node IAM polices"
+
+  value = [
+    "${aws_iam_policy.alb_ingress.arn}",
+    "${aws_iam_policy.autoscaler.arn}",
+    "${aws_iam_policy.alb_ingress.arn}",
+  ]
+}
+
+output "iam_autoscaler" {
+  description = "ARN of the EKS Cluster Node Cluster Autoscaler IAM policy"
+  value       = "${aws_iam_policy.autoscaler.arn}"
+}
+
+output "iam_cw_logs" {
+  description = "ARN of the EKS Cluster Node Cloudwatch Logs IAM policy"
+  value       = "${aws_iam_policy.alb_ingress.arn}"
 }
 
 output "kubeconfig" {
   description = "Contents of the kubeconfig file used to connect to the cluster for management.  Value should be retrieved with CLI or SDK to ensure proper formatting"
   value       = "${data.template_file.kubeconfig.rendered}"
+}
+
+output "kube_map_roles" {
+  description = "The string value used to configure the cluster with the kubernetes_config_map resource"
+  value       = "${join("", data.template_file.map_roles.*.rendered)}"
 }
 
 output "name" {
@@ -25,8 +57,5 @@ output "name" {
 
 output "setup" {
   description = "Default EKS bootstrapping script for EC2"
-
-  value = <<EOF
-/etc/eks/bootstrap.sh ${var.name} ${var.bootstrap_arguments}
-EOF
+  value       = "/etc/eks/bootstrap.sh ${var.name} ${var.bootstrap_arguments}\n"
 }

--- a/modules/cluster/outputs.tf
+++ b/modules/cluster/outputs.tf
@@ -17,27 +17,27 @@ output "endpoint" {
 
 output "iam_alb_ingress" {
   description = "ARN of the EKS Cluster Node ALB Ingress Controller IAM policy"
-  value       = "${aws_iam_policy.alb_ingress.arn}"
+  value       = "${join(",", aws_iam_policy.alb_ingress.*.arn)}"
 }
 
 output "iam_all_node_policies" {
   description = "ARN of all EKS Cluster Node IAM polices"
 
-  value = [
-    "${aws_iam_policy.alb_ingress.arn}",
-    "${aws_iam_policy.autoscaler.arn}",
-    "${aws_iam_policy.alb_ingress.arn}",
-  ]
+  value = "${concat(
+    aws_iam_policy.alb_ingress.*.arn,
+    aws_iam_policy.autoscaler.*.arn,
+    list(aws_iam_policy.cw_logs.arn),
+  )}"
 }
 
 output "iam_autoscaler" {
   description = "ARN of the EKS Cluster Node Cluster Autoscaler IAM policy"
-  value       = "${aws_iam_policy.autoscaler.arn}"
+  value       = "${join(",", aws_iam_policy.autoscaler.*.arn)}"
 }
 
 output "iam_cw_logs" {
   description = "ARN of the EKS Cluster Node Cloudwatch Logs IAM policy"
-  value       = "${aws_iam_policy.alb_ingress.arn}"
+  value       = "${aws_iam_policy.cw_logs.arn}"
 }
 
 output "kubeconfig" {

--- a/modules/cluster/text/map_roles.txt
+++ b/modules/cluster/text/map_roles.txt
@@ -1,0 +1,5 @@
+- rolearn: ${iam_role}
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+   - system:bootstrappers
+   - system:nodes

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -1,3 +1,15 @@
+variable "alb_ingress_controller_enable" {
+  description = "A boolean value that determines if IAM policies related to ALB ingress controller should be created."
+  type        = "string"
+  default     = true
+}
+
+variable "cluster_autoscaler_enable" {
+  description = "A boolean value that determines if IAM policies related to cluster autoscaler should be created."
+  type        = "string"
+  default     = true
+}
+
 variable "name" {
   description = "The desired name for the EKS cluster."
   type        = "string"

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -49,3 +49,9 @@ variable "enabled_cluster_log_types" {
     "scheduler",
   ]
 }
+
+variable "wait_for_cluster" {
+  description = "A variable to control whether we pause deployment after creating the EKS cluster to allow time to fully launch."
+  type        = "string"
+  default     = true
+}

--- a/modules/kubernetes_components/README.md
+++ b/modules/kubernetes_components/README.md
@@ -1,6 +1,6 @@
 # aws-terraform-eks/modules/kubernetes_components
 
-This module
+This module creates the other required components for EKS to allow additional features like ALB Ingress and Cluster Autoscaler.
 
 ## Basic Usage
 
@@ -20,18 +20,18 @@ Full working references are available at [examples](examples)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alb\_ingress\_controller\_enable | A variable to control whether cluster autoscaler is enabled | string | `"true"` | no |
+| alb\_ingress\_controller\_enable | A variable to control whether or not the ALB Ingress resources are enabled | string | `"true"` | no |
 | alb\_max\_api\_retries | Maximum number of times to retry the aws calls | string | `"10"` | no |
 | cluster\_autoscaler\_cpu\_limits | CPU Limits for the CA Pod | string | `"100m"` | no |
 | cluster\_autoscaler\_cpu\_requests | CPU Requests for the CA Pod | string | `"100m"` | no |
-| cluster\_autoscaler\_enable | A variable to control whether cluster autoscaler is enabled | string | `"true"` | no |
+| cluster\_autoscaler\_enable | A variable to control whether CA is enabled | string | `"true"` | no |
 | cluster\_autoscaler\_mem\_limits | Mem Limits for the CA Pod | string | `"300Mi"` | no |
 | cluster\_autoscaler\_mem\_requests | Mem requests for the CA Pod | string | `"300Mi"` | no |
 | cluster\_autoscaler\_scale\_down\_delay | CA Scale down delay | string | `"5m"` | no |
-| cluster\_autoscaler\_tag\_key | Tag key used with cluster autoscaler. Change this only if you have multiple EKS clusters in the same account. | string | `"k8s.io/cluster-autoscaler/enabled"` | no |
+| cluster\_autoscaler\_tag\_key | Tag key used with CA. Change this only if you have multiple EKS clusters in the same account. | string | `"k8s.io/cluster-autoscaler/enabled"` | no |
 | cluster\_name | The name of the EKS Cluster | string | n/a | yes |
 | kube\_map\_roles | The string used to configure the EKS cluster, retrieved from the EKS Cluster module | string | n/a | yes |
 | kubernetes\_deployment\_create\_timeout | Timeout for creating instances, replicas, and restoring from Snapshots | string | `"30m"` | no |
 | kubernetes\_deployment\_delete\_timeout | Timeout for destroying databases. This includes the time required to take snapshots | string | `"30m"` | no |
-| kubernetes\_deployment\_update\_timeout | Timeout for datbabse modifications | string | `"30m"` | no |
+| kubernetes\_deployment\_update\_timeout | Timeout for database modifications | string | `"30m"` | no |
 

--- a/modules/kubernetes_components/README.md
+++ b/modules/kubernetes_components/README.md
@@ -1,0 +1,37 @@
+# aws-terraform-eks/modules/kubernetes_components
+
+This module
+
+## Basic Usage
+
+```
+module "eks_config" {
+ source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/kubernetes_components/?ref=v0.0.5"
+
+ cluster_name    = "${module.eks_cluster.name}"
+ kube_map_roles  = "${module.eks_cluster.kube_map_roles}"
+
+}
+```
+
+Full working references are available at [examples](examples)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| alb\_ingress\_controller\_enable | A variable to control whether cluster autoscaler is enabled | string | `"true"` | no |
+| alb\_max\_api\_retries | Maximum number of times to retry the aws calls | string | `"10"` | no |
+| cluster\_autoscaler\_cpu\_limits | CPU Limits for the CA Pod | string | `"100m"` | no |
+| cluster\_autoscaler\_cpu\_requests | CPU Requests for the CA Pod | string | `"100m"` | no |
+| cluster\_autoscaler\_enable | A variable to control whether cluster autoscaler is enabled | string | `"true"` | no |
+| cluster\_autoscaler\_mem\_limits | Mem Limits for the CA Pod | string | `"300Mi"` | no |
+| cluster\_autoscaler\_mem\_requests | Mem requests for the CA Pod | string | `"300Mi"` | no |
+| cluster\_autoscaler\_scale\_down\_delay | CA Scale down delay | string | `"5m"` | no |
+| cluster\_autoscaler\_tag\_key | Tag key used with cluster autoscaler. Change this only if you have multiple EKS clusters in the same account. | string | `"k8s.io/cluster-autoscaler/enabled"` | no |
+| cluster\_name | The name of the EKS Cluster | string | n/a | yes |
+| kube\_map\_roles | The string used to configure the EKS cluster, retrieved from the EKS Cluster module | string | n/a | yes |
+| kubernetes\_deployment\_create\_timeout | Timeout for creating instances, replicas, and restoring from Snapshots | string | `"30m"` | no |
+| kubernetes\_deployment\_delete\_timeout | Timeout for destroying databases. This includes the time required to take snapshots | string | `"30m"` | no |
+| kubernetes\_deployment\_update\_timeout | Timeout for datbabse modifications | string | `"30m"` | no |
+

--- a/modules/kubernetes_components/examples/main.tf
+++ b/modules/kubernetes_components/examples/main.tf
@@ -1,0 +1,152 @@
+provider "aws" {
+  version = "~> 2.41"
+  region  = "us-west-2"
+}
+
+provider "random" {
+  version = "~> 1.0"
+}
+
+# due to an issue with the K8S provider we are having to pin it to 1.9 at the latest until this issue is resolved.
+# https://github.com/terraform-providers/terraform-provider-kubernetes/issues/679
+
+provider "kubernetes" {
+  version                = "= 1.9"
+  host                   = "${module.eks.endpoint}"
+  cluster_ca_certificate = "${base64decode(module.eks.certificate_authority_data)}"
+  token                  = "${data.aws_eks_cluster_auth.eks.token}"
+  load_config_file       = false
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  name = "${module.eks.name}"
+}
+
+resource "random_string" "r_string" {
+  length  = 6
+  special = false
+}
+
+locals {
+  cluster_name = "Test-EKS-${random_string.r_string.result}"
+}
+
+module "vpc" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.10"
+
+  vpc_name    = "Test-EKS-VPC-${random_string.r_string.result}"
+  custom_tags = "${map("kubernetes.io/cluster/${local.cluster_name}", "shared")}"
+
+  public_subnet_tags = [
+    {
+      "kubernetes.io/role/elb" = 1
+    },
+  ]
+}
+
+module "sg" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=v0.0.6"
+
+  resource_name = "Test-SG-${random_string.r_string.result}"
+  vpc_id        = "${module.vpc.vpc_id}"
+}
+
+module "eks" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/kubernetes_components?ref=v0.0.5"
+
+  name                      = "${local.cluster_name}"
+  enabled_cluster_log_types = []                                                                 #  All are enabled by default. Test to ensure disabling doesn't break
+  subnets                   = "${concat(module.vpc.public_subnets, module.vpc.private_subnets)}" #  Required
+  security_groups           = ["${module.sg.eks_control_plane_security_group_id}"]
+  worker_roles              = ["${module.worker1.iam_role}", "${module.worker2.iam_role}"]
+  worker_roles_count        = "2"
+}
+
+data "aws_ami" "eks" {
+  most_recent = true
+  owners      = ["602401143452"]
+
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+module "worker1" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.25"
+
+  ec2_os                                 = "amazoneks"
+  enable_scaling_actions                 = false
+  image_id                               = "${data.aws_ami.eks.image_id}"
+  initial_userdata_commands              = "${module.eks.setup}"
+  instance_type                          = "t2.medium"
+  instance_role_managed_policy_arns      = "${module.eks.iam_all_node_policies}"
+  instance_role_managed_policy_arn_count = "3"
+  resource_name                          = "Test_eks_worker1_nodes_${random_string.r_string.result}"
+  scaling_min                            = "1"
+  scaling_max                            = "2"
+  security_group_list                    = ["${module.sg.eks_worker_security_group_id}"]
+  subnets                                = ["${element(module.vpc.private_subnets, 0)}"]
+
+  additional_tags = [
+    {
+      key                 = "kubernetes.io/cluster/${module.eks.name}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "k8s.io/cluster-autoscaler/enabled"
+      value               = ""
+      propagate_at_launch = true
+    },
+  ]
+}
+
+module "worker2" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=v0.0.25"
+
+  ec2_os                                 = "amazoneks"
+  enable_scaling_actions                 = false
+  image_id                               = "${data.aws_ami.eks.image_id}"
+  initial_userdata_commands              = "${module.eks.setup}"
+  instance_role_managed_policy_arn_count = "3"
+  instance_type                          = "t2.medium"
+  resource_name                          = "Test_eks_worker2_nodes_${random_string.r_string.result}"
+  scaling_min                            = "1"
+  scaling_max                            = "2"
+  security_group_list                    = ["${module.sg.eks_worker_security_group_id}"]
+  subnets                                = ["${element(module.vpc.private_subnets, 1)}"]
+
+  additional_tags = [
+    {
+      key                 = "kubernetes.io/cluster/${module.eks.name}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "k8s.io/cluster-autoscaler/enabled"
+      value               = ""
+      propagate_at_launch = true
+    },
+  ]
+
+  instance_role_managed_policy_arns = [
+    "${module.eks.iam_alb_ingress}",
+    "${module.eks.iam_autoscaler}",
+    "${module.eks.iam_cw_logs}",
+  ]
+}
+
+module "kubernetes_components" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/kubernetes_components?ref=v0.0.5"
+
+  cluster_name                  = "${module.eks.name}"
+  kube_map_roles                = "${module.eks.kube_map_roles}"
+  cluster_autoscaler_enable     = true
+  alb_ingress_controller_enable = true
+}

--- a/modules/kubernetes_components/examples/main.tf
+++ b/modules/kubernetes_components/examples/main.tf
@@ -34,8 +34,11 @@ locals {
 module "vpc" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork?ref=v0.0.10"
 
-  vpc_name    = "Test-EKS-VPC-${random_string.r_string.result}"
-  custom_tags = "${map("kubernetes.io/cluster/${local.cluster_name}", "shared")}"
+  vpc_name = "Test-EKS-VPC-${random_string.r_string.result}"
+
+  custom_tags = {
+    "kubernetes.io/cluster/${local.eks_cluster_name}" = "shared"
+  }
 
   public_subnet_tags = [
     {
@@ -52,7 +55,7 @@ module "sg" {
 }
 
 module "eks" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/kubernetes_components?ref=v0.0.5"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/cluster?ref=v0.0.5"
 
   name                      = "${local.cluster_name}"
   enabled_cluster_log_types = []                                                                 #  All are enabled by default. Test to ensure disabling doesn't break

--- a/modules/kubernetes_components/main.tf
+++ b/modules/kubernetes_components/main.tf
@@ -1,7 +1,7 @@
 /**
  * # aws-terraform-eks/modules/kubernetes_components
  *
- * This module
+ * This module creates the other required components for EKS to allow additional features like ALB Ingress and Cluster Autoscaler.
  *
  *## Basic Usage
  *
@@ -293,9 +293,9 @@ resource "kubernetes_cluster_role" "alb_ingress_controller" {
   metadata {
     name = "alb-ingress-controller"
 
-    labels {
+    labels = [{
       "app.kubernetes.io/name" = "alb-ingress-controller"
-    }
+    }]
   }
 
   rule {
@@ -319,9 +319,9 @@ resource "kubernetes_cluster_role_binding" "alb_ingress_controller" {
   metadata {
     name = "alb-ingress-controller"
 
-    labels {
+    labels = [{
       "app.kubernetes.io/name" = "alb-ingress-controller"
-    }
+    }]
   }
 
   subject {
@@ -346,9 +346,9 @@ resource "kubernetes_service_account" "alb_ingress_controller" {
     name      = "alb-ingress-controller"
     namespace = "kube-system"
 
-    labels {
+    labels = [{
       "app.kubernetes.io/name" = "alb-ingress-controller"
-    }
+    }]
   }
 
   automount_service_account_token = true
@@ -362,23 +362,23 @@ resource "kubernetes_deployment" "alb_ingress_controller" {
     name      = "alb-ingress-controller"
     namespace = "kube-system"
 
-    labels {
+    labels = [{
       "app.kubernetes.io/name" = "alb-ingress-controller"
-    }
+    }]
   }
 
   spec {
     selector {
-      match_labels {
+      match_labels = [{
         "app.kubernetes.io/name" = "alb-ingress-controller"
-      }
+      }]
     }
 
     template {
       metadata {
-        labels {
+        labels = [{
           "app.kubernetes.io/name" = "alb-ingress-controller"
-        }
+        }]
       }
 
       spec {

--- a/modules/kubernetes_components/main.tf
+++ b/modules/kubernetes_components/main.tf
@@ -1,0 +1,404 @@
+/**
+ * # aws-terraform-eks/modules/kubernetes_components
+ *
+ * This module
+ *
+ *## Basic Usage
+ *
+ *```
+ *module "eks_config" {
+ *  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-eks//modules/kubernetes_components/?ref=v0.0.5"
+ *
+ *  cluster_name    = "${module.eks_cluster.name}"
+ *  kube_map_roles  = "${module.eks_cluster.kube_map_roles}"
+ *
+ *}
+ *```
+ *
+ * Full working references are available at [examples](examples)
+ */
+
+resource "kubernetes_config_map" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data {
+    mapRoles = "${var.kube_map_roles}"
+  }
+}
+
+resource "kubernetes_service_account" "cluster_autoscaler" {
+  count = "${var.cluster_autoscaler_enable ? 1 : 0}"
+
+  metadata {
+    name      = "cluster-autoscaler"
+    namespace = "kube-system"
+
+    labels {
+      k8s-addon = "cluster-autoscaler.addons.k8s.io"
+      k8s-app   = "cluster-autoscaler"
+    }
+  }
+
+  automount_service_account_token = true
+  depends_on                      = ["kubernetes_config_map.aws_auth"]
+}
+
+resource "kubernetes_cluster_role" "cluster_autoscaler" {
+  count = "${var.cluster_autoscaler_enable ? 1 : 0}"
+
+  metadata {
+    name = "cluster-autoscaler"
+
+    labels {
+      k8s-addon = "cluster-autoscaler.addons.k8s.io"
+      k8s-app   = "cluster-autoscaler"
+    }
+  }
+
+  rule {
+    verbs      = ["create", "patch"]
+    api_groups = [""]
+    resources  = ["events", "endpoints"]
+  }
+
+  rule {
+    verbs      = ["create"]
+    api_groups = [""]
+    resources  = ["pods/eviction"]
+  }
+
+  rule {
+    verbs      = ["update"]
+    api_groups = [""]
+    resources  = ["pods/status"]
+  }
+
+  rule {
+    verbs          = ["get", "update"]
+    api_groups     = [""]
+    resources      = ["endpoints"]
+    resource_names = ["cluster-autoscaler"]
+  }
+
+  rule {
+    verbs      = ["watch", "list", "get", "update"]
+    api_groups = [""]
+    resources  = ["nodes"]
+  }
+
+  rule {
+    verbs      = ["watch", "list", "get"]
+    api_groups = [""]
+    resources  = ["pods", "services", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes"]
+  }
+
+  rule {
+    verbs      = ["watch", "list", "get"]
+    api_groups = ["extensions"]
+    resources  = ["replicasets", "daemonsets"]
+  }
+
+  rule {
+    verbs      = ["watch", "list"]
+    api_groups = ["policy"]
+    resources  = ["poddisruptionbudgets"]
+  }
+
+  rule {
+    verbs      = ["watch", "list", "get"]
+    api_groups = ["apps"]
+    resources  = ["statefulsets", "replicasets", "daemonsets"]
+  }
+
+  rule {
+    verbs      = ["watch", "list", "get"]
+    api_groups = ["storage.k8s.io"]
+    resources  = ["storageclasses"]
+  }
+
+  rule {
+    verbs      = ["get", "list", "watch", "patch"]
+    api_groups = ["batch", "extensions"]
+    resources  = ["jobs"]
+  }
+}
+
+resource "kubernetes_role" "cluster_autoscaler" {
+  count = "${var.cluster_autoscaler_enable ? 1 : 0}"
+
+  metadata {
+    name      = "cluster-autoscaler"
+    namespace = "kube-system"
+
+    labels {
+      k8s-addon = "cluster-autoscaler.addons.k8s.io"
+      k8s-app   = "cluster-autoscaler"
+    }
+  }
+
+  rule {
+    verbs      = ["create", "list", "watch"]
+    api_groups = [""]
+    resources  = ["configmaps"]
+  }
+
+  rule {
+    verbs          = ["delete", "get", "update", "watch"]
+    api_groups     = [""]
+    resources      = ["configmaps"]
+    resource_names = ["cluster-autoscaler-status", "cluster-autoscaler-priority-expander"]
+  }
+
+  depends_on = ["kubernetes_config_map.aws_auth"]
+}
+
+resource "kubernetes_cluster_role_binding" "cluster_autoscaler" {
+  count = "${var.cluster_autoscaler_enable ? 1 : 0}"
+
+  metadata {
+    name = "cluster-autoscaler"
+
+    labels {
+      k8s-addon = "cluster-autoscaler.addons.k8s.io"
+      k8s-app   = "cluster-autoscaler"
+    }
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "cluster-autoscaler"
+    namespace = "kube-system"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-autoscaler"
+  }
+}
+
+resource "kubernetes_role_binding" "cluster_autoscaler" {
+  count = "${var.cluster_autoscaler_enable ? 1 : 0}"
+
+  metadata {
+    name      = "cluster-autoscaler"
+    namespace = "kube-system"
+
+    labels {
+      k8s-addon = "cluster-autoscaler.addons.k8s.io"
+      k8s-app   = "cluster-autoscaler"
+    }
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "cluster-autoscaler"
+    namespace = "kube-system"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "cluster-autoscaler"
+  }
+
+  depends_on = ["kubernetes_config_map.aws_auth"]
+}
+
+resource "kubernetes_deployment" "cluster_autoscaler" {
+  count = "${var.cluster_autoscaler_enable ? 1 : 0}"
+
+  metadata {
+    name      = "cluster-autoscaler"
+    namespace = "kube-system"
+
+    labels {
+      app = "cluster-autoscaler"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels {
+        app = "cluster-autoscaler"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          app = "cluster-autoscaler"
+        }
+      }
+
+      spec {
+        service_account_name             = "cluster-autoscaler"
+        termination_grace_period_seconds = "60"
+        automount_service_account_token  = "true"
+
+        volume {
+          name = "ssl-certs"
+
+          host_path {
+            path = "/etc/ssl/certs/ca-bundle.crt"
+          }
+        }
+
+        container {
+          name    = "cluster-autoscaler"
+          image   = "gcr.io/google-containers/cluster-autoscaler:v1.15.0"
+          command = ["./cluster-autoscaler", "--v=4", "--stderrthreshold=info", "--cloud-provider=aws", "--skip-nodes-with-local-storage=false", "--expander=least-waste", "--node-group-auto-discovery=asg:tag=${var.cluster_autoscaler_tag_key}", "--scale-down-delay-after-add=${var.cluster_autoscaler_scale_down_delay}"]
+
+          resources {
+            limits {
+              cpu    = "${var.cluster_autoscaler_cpu_limits}"
+              memory = "${var.cluster_autoscaler_mem_limits}"
+            }
+
+            requests {
+              cpu    = "${var.cluster_autoscaler_cpu_requests}"
+              memory = "${var.cluster_autoscaler_mem_requests}"
+            }
+          }
+
+          volume_mount {
+            name       = "ssl-certs"
+            read_only  = true
+            mount_path = "/etc/ssl/certs/ca-certificates.crt"
+          }
+
+          image_pull_policy = "Always"
+        }
+      }
+    }
+  }
+
+  timeouts = {
+    create = "${var.kubernetes_deployment_create_timeout}"
+    update = "${var.kubernetes_deployment_update_timeout}"
+    delete = "${var.kubernetes_deployment_delete_timeout}"
+  }
+
+  depends_on = ["kubernetes_config_map.aws_auth"]
+}
+
+resource "kubernetes_cluster_role" "alb_ingress_controller" {
+  count = "${var.alb_ingress_controller_enable ? 1 : 0}"
+
+  metadata {
+    name = "alb-ingress-controller"
+
+    labels {
+      "app.kubernetes.io/name" = "alb-ingress-controller"
+    }
+  }
+
+  rule {
+    verbs      = ["create", "get", "list", "update", "watch", "patch"]
+    api_groups = ["", "extensions"]
+    resources  = ["configmaps", "endpoints", "events", "ingresses", "ingresses/status", "services"]
+  }
+
+  rule {
+    verbs      = ["get", "list", "watch"]
+    api_groups = ["", "extensions"]
+    resources  = ["nodes", "pods", "secrets", "services", "namespaces"]
+  }
+
+  depends_on = ["kubernetes_config_map.aws_auth"]
+}
+
+resource "kubernetes_cluster_role_binding" "alb_ingress_controller" {
+  count = "${var.alb_ingress_controller_enable ? 1 : 0}"
+
+  metadata {
+    name = "alb-ingress-controller"
+
+    labels {
+      "app.kubernetes.io/name" = "alb-ingress-controller"
+    }
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "alb-ingress-controller"
+    namespace = "kube-system"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "alb-ingress-controller"
+  }
+
+  depends_on = ["kubernetes_config_map.aws_auth"]
+}
+
+resource "kubernetes_service_account" "alb_ingress_controller" {
+  count = "${var.alb_ingress_controller_enable ? 1 : 0}"
+
+  metadata {
+    name      = "alb-ingress-controller"
+    namespace = "kube-system"
+
+    labels {
+      "app.kubernetes.io/name" = "alb-ingress-controller"
+    }
+  }
+
+  automount_service_account_token = true
+  depends_on                      = ["kubernetes_config_map.aws_auth"]
+}
+
+resource "kubernetes_deployment" "alb_ingress_controller" {
+  count = "${var.alb_ingress_controller_enable ? 1 : 0}"
+
+  metadata {
+    name      = "alb-ingress-controller"
+    namespace = "kube-system"
+
+    labels {
+      "app.kubernetes.io/name" = "alb-ingress-controller"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels {
+        "app.kubernetes.io/name" = "alb-ingress-controller"
+      }
+    }
+
+    template {
+      metadata {
+        labels {
+          "app.kubernetes.io/name" = "alb-ingress-controller"
+        }
+      }
+
+      spec {
+        container {
+          name  = "alb-ingress-controller"
+          image = "docker.io/amazon/aws-alb-ingress-controller:v1.1.2"
+          args  = ["--ingress-class=alb", "--cluster-name=${var.cluster_name}", "--aws-max-retries=${var.alb_max_api_retries}", "--v=5"]
+        }
+
+        service_account_name            = "alb-ingress-controller"
+        automount_service_account_token = "true"
+      }
+    }
+  }
+
+  timeouts = {
+    create = "${var.kubernetes_deployment_create_timeout}"
+    update = "${var.kubernetes_deployment_update_timeout}"
+    delete = "${var.kubernetes_deployment_delete_timeout}"
+  }
+
+  depends_on = ["kubernetes_config_map.aws_auth"]
+}

--- a/modules/kubernetes_components/variables.tf
+++ b/modules/kubernetes_components/variables.tf
@@ -1,0 +1,84 @@
+variable "cluster_autoscaler_enable" {
+  description = "A variable to control whether cluster autoscaler is enabled"
+  type        = "string"
+  default     = true
+}
+
+variable "alb_ingress_controller_enable" {
+  description = "A variable to control whether cluster autoscaler is enabled"
+  type        = "string"
+  default     = true
+}
+
+variable "kubernetes_deployment_create_timeout" {
+  description = "Timeout for creating instances, replicas, and restoring from Snapshots"
+  type        = "string"
+  default     = "30m"
+}
+
+variable "kubernetes_deployment_update_timeout" {
+  description = "Timeout for datbabse modifications"
+  type        = "string"
+  default     = "30m"
+}
+
+variable "kubernetes_deployment_delete_timeout" {
+  description = "Timeout for destroying databases. This includes the time required to take snapshots"
+  type        = "string"
+  default     = "30m"
+}
+
+## Cluster Autoscaler
+
+variable "cluster_autoscaler_tag_key" {
+  description = "Tag key used with cluster autoscaler. Change this only if you have multiple EKS clusters in the same account."
+  type        = "string"
+  default     = "k8s.io/cluster-autoscaler/enabled"
+}
+
+variable "cluster_autoscaler_cpu_limits" {
+  description = "CPU Limits for the CA Pod"
+  type        = "string"
+  default     = "100m"
+}
+
+variable "cluster_autoscaler_mem_limits" {
+  description = "Mem Limits for the CA Pod"
+  type        = "string"
+  default     = "300Mi"
+}
+
+variable "cluster_autoscaler_cpu_requests" {
+  description = "CPU Requests for the CA Pod"
+  type        = "string"
+  default     = "100m"
+}
+
+variable "cluster_autoscaler_mem_requests" {
+  description = "Mem requests for the CA Pod"
+  type        = "string"
+  default     = "300Mi"
+}
+
+variable "cluster_autoscaler_scale_down_delay" {
+  description = "CA Scale down delay"
+  type        = "string"
+  default     = "5m"
+}
+
+## ALB
+variable "alb_max_api_retries" {
+  description = "Maximum number of times to retry the aws calls"
+  type        = "string"
+  default     = "10"
+}
+
+variable "cluster_name" {
+  description = "The name of the EKS Cluster"
+  type        = "string"
+}
+
+variable "kube_map_roles" {
+  description = "The string used to configure the EKS cluster, retrieved from the EKS Cluster module"
+  type        = "string"
+}

--- a/modules/kubernetes_components/variables.tf
+++ b/modules/kubernetes_components/variables.tf
@@ -1,11 +1,11 @@
 variable "cluster_autoscaler_enable" {
-  description = "A variable to control whether cluster autoscaler is enabled"
+  description = "A variable to control whether CA is enabled"
   type        = "string"
   default     = true
 }
 
 variable "alb_ingress_controller_enable" {
-  description = "A variable to control whether cluster autoscaler is enabled"
+  description = "A variable to control whether or not the ALB Ingress resources are enabled"
   type        = "string"
   default     = true
 }
@@ -17,7 +17,7 @@ variable "kubernetes_deployment_create_timeout" {
 }
 
 variable "kubernetes_deployment_update_timeout" {
-  description = "Timeout for datbabse modifications"
+  description = "Timeout for database modifications"
   type        = "string"
   default     = "30m"
 }
@@ -28,10 +28,10 @@ variable "kubernetes_deployment_delete_timeout" {
   default     = "30m"
 }
 
-## Cluster Autoscaler
+## Cluster Autoscaler AKA CA
 
 variable "cluster_autoscaler_tag_key" {
-  description = "Tag key used with cluster autoscaler. Change this only if you have multiple EKS clusters in the same account."
+  description = "Tag key used with CA. Change this only if you have multiple EKS clusters in the same account."
   type        = "string"
   default     = "k8s.io/cluster-autoscaler/enabled"
 }
@@ -66,7 +66,7 @@ variable "cluster_autoscaler_scale_down_delay" {
   default     = "5m"
 }
 
-## ALB
+## ALB Ingress
 variable "alb_max_api_retries" {
   description = "Maximum number of times to retry the aws calls"
   type        = "string"

--- a/tests/cluster/main.tf
+++ b/tests/cluster/main.tf
@@ -11,6 +11,18 @@ provider "random" {
   version = "~> 1.0"
 }
 
+provider "kubernetes" {
+  version                = "= 1.9"
+  host                   = "${module.eks.endpoint}"
+  cluster_ca_certificate = "${base64decode(module.eks.certificate_authority_data)}"
+  token                  = "${data.aws_eks_cluster_auth.eks.token}"
+  load_config_file       = false
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  name = "${module.eks.name}"
+}
+
 resource "random_string" "r_string" {
   length  = 6
   special = false
@@ -47,11 +59,8 @@ module "eks" {
   security_groups           = ["${module.eks_sg.eks_control_plane_security_group_id}"]
   worker_roles              = ["${module.ec2_asg.iam_role}"]
   worker_roles_count        = "1"
-
-  # kubernetes_version = ""
 }
 
-# Lookup the correct AMI based on the region specified
 data "aws_ami" "eks" {
   most_recent = true
   owners      = ["602401143452"]
@@ -70,13 +79,17 @@ data "aws_ami" "eks" {
 module "ec2_asg" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=master"
 
-  ec2_os                    = "amazoneks"
-  subnets                   = "${data.aws_subnet_ids.selected.ids}"
-  image_id                  = "${data.aws_ami.eks.image_id}"
-  instance_type             = "t2.medium"
-  resource_name             = "Test_eks_worker_nodes_${random_string.r_string.result}"
-  security_group_list       = ["${module.eks_sg.eks_worker_security_group_id}"]
-  initial_userdata_commands = "${module.eks.setup}"
+  ec2_os                                 = "amazoneks"
+  image_id                               = "${data.aws_ami.eks.image_id}"
+  initial_userdata_commands              = "${module.eks.setup}"
+  instance_type                          = "t2.medium"
+  instance_role_managed_policy_arns      = "${module.eks.iam_all_node_policies}"
+  instance_role_managed_policy_arn_count = "3"
+  resource_name                          = "Test_eks_worker_nodes_${random_string.r_string.result}"
+  scaling_min                            = "1"
+  scaling_max                            = "2"
+  security_group_list                    = ["${module.eks_sg.eks_worker_security_group_id}"]
+  subnets                                = "${data.aws_subnet_ids.selected.ids}"
 
   additional_tags = [
     {
@@ -84,5 +97,19 @@ module "ec2_asg" {
       value               = "owned"
       propagate_at_launch = true
     },
+    {
+      key                 = "k8s.io/cluster-autoscaler/enabled"
+      value               = ""
+      propagate_at_launch = true
+    },
   ]
+}
+
+module "kubernetes_components" {
+  source = "../../module/modules/kubernetes_components"
+
+  cluster_name                  = "${module.eks.name}"
+  kube_map_roles                = "${module.eks.kube_map_roles}"
+  cluster_autoscaler_enable     = true
+  alb_ingress_controller_enable = true
 }

--- a/tests/cluster/main.tf
+++ b/tests/cluster/main.tf
@@ -44,7 +44,7 @@ data "aws_subnet_ids" "selected" {
 }
 
 module "eks_sg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=master"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group?ref=tf_v0.11"
 
   resource_name = "Test-EKS-SG-${random_string.r_string.result}"
   vpc_id        = "${data.aws_vpc.selected.id}"
@@ -77,7 +77,7 @@ data "aws_ami" "eks" {
 }
 
 module "ec2_asg" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=master"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg?ref=tf_v0.11"
 
   ec2_os                                 = "amazoneks"
   image_id                               = "${data.aws_ami.eks.image_id}"

--- a/tests/cluster/outputs.tf
+++ b/tests/cluster/outputs.tf
@@ -1,9 +1,0 @@
-output "kubeconfig" {
-  description = "output of the kubeconfig"
-  value       = "${module.eks.kubeconfig}"
-}
-
-output "aws_auth_cm" {
-  description = "output of the aws auth"
-  value       = "${module.eks.aws_auth_cm}"
-}


### PR DESCRIPTION
Adjust EKS modules to handle testing timeout errors

##### Corresponding Issue(s):
 - [MPCSUPENG-620](https://jira.rax.io/browse/MPCSUPENG-620)

##### Summary of change(s):
- Adds `kubernetes_components` submodule, to manage EKS configuration using the `kubernetes` terraform provider.
  - Initial supported components include Cluster Autoscaler and ALB Ingress controller.  Creation of each component is enabled via a control variable, and has additional variables allowing customization.
- Updates EKS Cluster submodule to add creation of EKS related IAM policies and waiter to allow API endpoint to come online
  - IAM policies created to grant required permissions for Cluster Autoscaler, Cloudwatch Logs access, and ALB Ingress controller.  These policies can be selectively applied when creating the related ASG\AR resources.
  - Adds output of map roles subsection of kubernetes configuration file, allowing configuration of access via the kubernetes components submodule.
##### Reason for Change(s):

- Implementation of EKS CLuster Autoscaler and EKS ALB Ingress Controller

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Yes, ASG related changes made in rackspace-infrastructure-automation/aws-terraform-ec2_asg#46

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes README.md files have been updated.

##### Do examples need to be updated based on changes?
Yes, examples have been added and updated as necessary

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
